### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/601/015/5/1126010155.geojson
+++ b/data/112/601/015/5/1126010155.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Felidhoo"
     ],
+    "name:deu_x_preferred":[
+        "Felidhoo"
+    ],
     "name:div_x_preferred":[
         "\u078a\u07ac\u078d\u07a8\u078b\u07ab"
     ],
@@ -34,10 +37,16 @@
     "name:fas_x_preferred":[
         "\u0641\u0644\u06cc\u062f\u0647\u0648"
     ],
+    "name:fra_x_preferred":[
+        "Felidhoo"
+    ],
     "name:jpn_x_preferred":[
         "\u30d5\u30a7\u30ea\u30c9\u30a5\u30fc"
     ],
     "name:nld_x_preferred":[
+        "Felidhoo"
+    ],
+    "name:pol_x_preferred":[
         "Felidhoo"
     ],
     "name:slk_x_preferred":[
@@ -82,7 +91,7 @@
         }
     ],
     "wof:id":1126010155,
-    "wof:lastmodified":1566612153,
+    "wof:lastmodified":1690846532,
     "wof:name":"Felidhoo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/169/725/421169725.geojson
+++ b/data/421/169/725/421169725.geojson
@@ -17,11 +17,17 @@
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:arz_x_preferred":[
+        "\u062f\u0647\u064a\u062f\u0647\u0648"
+    ],
     "name:aze_x_preferred":[
         "Diddu"
     ],
     "name:ceb_x_preferred":[
         "Dhidhdhoo"
+    ],
+    "name:deu_x_preferred":[
+        "Dhiddhoo"
     ],
     "name:div_x_preferred":[
         "\u078b\u07a8\u0787\u07b0\u078b\u07ab"
@@ -48,6 +54,9 @@
         "Didd\u00fa"
     ],
     "name:swe_x_preferred":[
+        "Dhidhdhoo"
+    ],
+    "name:uzb_x_preferred":[
         "Dhidhdhoo"
     ],
     "qs:gn_country":"MV",
@@ -91,7 +100,7 @@
         }
     ],
     "wof:id":421169725,
-    "wof:lastmodified":1566612151,
+    "wof:lastmodified":1690846530,
     "wof:name":"Dhidhdhoo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/169/955/421169955.geojson
+++ b/data/421/169/955/421169955.geojson
@@ -23,6 +23,9 @@
     "name:dan_x_preferred":[
         "Thinadhoo"
     ],
+    "name:deu_x_preferred":[
+        "Thinadhoo"
+    ],
     "name:div_x_preferred":[
         "\u078c\u07a8\u0782\u07a6\u078b\u07ab"
     ],
@@ -48,6 +51,9 @@
         "Tinad\u00fa"
     ],
     "name:swe_x_preferred":[
+        "Thinadhoo"
+    ],
+    "name:uzb_x_preferred":[
         "Thinadhoo"
     ],
     "qs:gn_country":"MV",
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":421169955,
-    "wof:lastmodified":1566612151,
+    "wof:lastmodified":1690846529,
     "wof:name":"Thinadhoo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/198/743/421198743.geojson
+++ b/data/421/198/743/421198743.geojson
@@ -32,6 +32,12 @@
     "name:slk_x_preferred":[
         "Mag\u00fad\u00fa"
     ],
+    "name:swe_x_preferred":[
+        "Magoodhoo"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u0433\u0443\u0434\u0433\u0443"
+    ],
     "qs:gn_country":"MV",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1337608,
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":421198743,
-    "wof:lastmodified":1566612152,
+    "wof:lastmodified":1690846530,
     "wof:name":"Magoodhoo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/203/963/421203963.geojson
+++ b/data/421/203/963/421203963.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Naifaru"
     ],
+    "name:deu_x_preferred":[
+        "Naifaru"
+    ],
     "name:div_x_preferred":[
         "\u0782\u07a6\u0787\u07a8\u078a\u07a6\u0783\u07aa"
     ],
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":421203963,
-    "wof:lastmodified":1566612151,
+    "wof:lastmodified":1690846530,
     "wof:name":"Naifaru",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/323/05/85632305.geojson
+++ b/data/856/323/05/85632305.geojson
@@ -46,8 +46,14 @@
     "name:amh_x_preferred":[
         "\u121b\u120d\u12f2\u126d\u1235"
     ],
+    "name:ami_x_preferred":[
+        "Maldives"
+    ],
     "name:ang_x_preferred":[
         "Maldif\u012bega"
+    ],
+    "name:anp_x_preferred":[
+        "\u092e\u093e\u0932\u0926\u0940\u0935"
     ],
     "name:ara_x_preferred":[
         "\u062c\u0632\u0631 \u0627\u0644\u0645\u0627\u0644\u062f\u064a\u0641"
@@ -71,6 +77,12 @@
     ],
     "name:ast_x_preferred":[
         "Maldives"
+    ],
+    "name:ava_x_preferred":[
+        "\u041c\u0430\u043b\u0434\u0438\u0432\u0430\u0431\u0438"
+    ],
+    "name:awa_x_preferred":[
+        "\u092e\u093e\u0932\u0926\u093f\u092d\u094d\u0938"
     ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u0644\u062f\u06cc\u0648"
@@ -115,8 +127,14 @@
     "name:bho_x_preferred":[
         "\u092e\u093e\u0932\u0926\u0940\u0935"
     ],
+    "name:bis_x_preferred":[
+        "Maldiv"
+    ],
     "name:bjn_x_preferred":[
         "Maladewa"
+    ],
+    "name:blk_x_preferred":[
+        "\u1019\u1031\u102c\u103a\u1012\u102f\u1032\u1000\u103a\u1001\u1019\u103a\u1038\u1011\u102e"
     ],
     "name:bod_x_preferred":[
         "\u0f58\u0f63\u0f0b\u0f51\u0f72\u0f0b\u0f5d\u0f7a\u0f66\u0f74\u0f0d"
@@ -169,6 +187,9 @@
     "name:ckb_x_preferred":[
         "\u0645\u0627\u0644\u062f\u06cc\u06a4"
     ],
+    "name:ckb_x_variant":[
+        "\u0645\u0627\u06b5\u062f\u06cc\u06a4"
+    ],
     "name:cor_x_preferred":[
         "Maldivys"
     ],
@@ -183,6 +204,9 @@
     ],
     "name:cze_x_variant":[
         "Maladivy"
+    ],
+    "name:dag_x_preferred":[
+        "Maldives"
     ],
     "name:dan_x_preferred":[
         "Maldiverne"
@@ -272,6 +296,9 @@
     "name:frr_x_preferred":[
         "Maledive"
     ],
+    "name:frr_x_variant":[
+        "Malediiwen"
+    ],
     "name:fry_x_preferred":[
         "Maldiven"
     ],
@@ -304,6 +331,12 @@
     ],
     "name:gom_x_preferred":[
         "\u092e\u093e\u0932\u0926\u0940\u0935"
+    ],
+    "name:gor_x_preferred":[
+        "Maladewa"
+    ],
+    "name:gpe_x_preferred":[
+        "Maldives"
     ],
     "name:grn_x_preferred":[
         "Maynd\u00edva"
@@ -375,6 +408,9 @@
     "name:ina_x_preferred":[
         "Maldives"
     ],
+    "name:ina_x_variant":[
+        "Maldivas"
+    ],
     "name:ind_x_preferred":[
         "Maladewa"
     ],
@@ -433,6 +469,9 @@
     "name:kbp_x_preferred":[
         "Maldivii"
     ],
+    "name:khm_x_preferred":[
+        "\u1798\u17c9\u17b6\u179b\u17cb\u178c\u17b8\u179c"
+    ],
     "name:kik_x_preferred":[
         "Modivu"
     ],
@@ -490,6 +529,9 @@
     "name:lit_x_variant":[
         "Maldivai"
     ],
+    "name:lld_x_preferred":[
+        "Maldives"
+    ],
     "name:lmo_x_preferred":[
         "Maldive"
     ],
@@ -520,6 +562,12 @@
     "name:mar_x_variant":[
         "\u092e\u093e\u0932\u0926\u0940\u0935\u094d\u091c"
     ],
+    "name:mhr_x_preferred":[
+        "\u041c\u0430\u043b\u044c\u0434\u0438\u0432"
+    ],
+    "name:min_x_preferred":[
+        "Maladewa"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0430\u043b\u0434\u0438\u0432\u0438"
     ],
@@ -533,8 +581,14 @@
         "Maldives",
         "Maldivi"
     ],
+    "name:mni_x_preferred":[
+        "\uabc3\uabe5\uabdc\uabd7\uabe4\uabda\uabc1"
+    ],
     "name:mon_x_preferred":[
         "\u041c\u0430\u043b\u044c\u0434\u0438\u0432"
+    ],
+    "name:mri_x_preferred":[
+        "Marat\u012bwi"
     ],
     "name:msa_x_preferred":[
         "Maldives"
@@ -578,6 +632,9 @@
     ],
     "name:nld_x_preferred":[
         "Maldiven"
+    ],
+    "name:nld_x_variant":[
+        "Malediven"
     ],
     "name:nno_x_preferred":[
         "Maldivane"
@@ -693,6 +750,9 @@
     "name:sgs_x_preferred":[
         "Mald\u012bv\u0101"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1019\u1031\u1083\u1087\u1010\u102d\u1015\u103a\u1088"
+    ],
     "name:sin_x_preferred":[
         "\u0db8\u0dcf\u0dbd\u0daf\u0dd2\u0dc0\u0dba\u0dd2\u0db1"
     ],
@@ -708,6 +768,15 @@
     ],
     "name:sme_x_preferred":[
         "Malediivvat"
+    ],
+    "name:smn_x_preferred":[
+        "Malediiveh"
+    ],
+    "name:smo_x_preferred":[
+        "Maldives"
+    ],
+    "name:sms_x_preferred":[
+        "Malediiv"
     ],
     "name:sna_x_preferred":[
         "Maldives"
@@ -769,6 +838,9 @@
     "name:tat_x_preferred":[
         "\u041c\u0430\u043b\u044c\u0434\u0438\u0432\u043b\u0430\u0440"
     ],
+    "name:tay_x_preferred":[
+        "Maldives"
+    ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c3e\u0c32\u0c4d\u0c26\u0c40\u0c35\u0c41\u0c32\u0c41"
     ],
@@ -797,6 +869,9 @@
         "Malativisi"
     ],
     "name:tpi_x_preferred":[
+        "Maldives"
+    ],
+    "name:trv_x_preferred":[
         "Maldives"
     ],
     "name:tuk_x_preferred":[
@@ -832,6 +907,9 @@
     ],
     "name:uzb_x_variant":[
         "Maldivalar"
+    ],
+    "name:vec_x_preferred":[
+        "Maldive"
     ],
     "name:vep_x_preferred":[
         "Mal'divan Sared"
@@ -903,7 +981,8 @@
         "\u9a6c\u5c14\u4ee3\u592b"
     ],
     "name:zho_x_variant":[
-        "\u99ac\u723e\u5730\u592b"
+        "\u99ac\u723e\u5730\u592b",
+        "\u99ac\u723e\u4ee3\u592b"
     ],
     "name:zho_yue_x_preferred":[
         "\u99ac\u723e\u4ee3\u592b"
@@ -1124,7 +1203,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1617827453,
+    "wof:lastmodified":1690846527,
     "wof:name":"Maldives",
     "wof:parent_id":102193527,
     "wof:placetype":"country",

--- a/data/856/740/49/85674049.geojson
+++ b/data/856/740/49/85674049.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u09b9\u09be \u0986\u09b2\u09bf\u09ab \u098f\u099f\u09b2"
     ],
+    "name:ben_x_variant":[
+        "\u09b9\u09be \u0986\u09b2\u09bf\u09ab \u09aa\u09cd\u09b0\u09ac\u09be\u09b2 \u09a6\u09cd\u09ac\u09c0\u09aa\u09aa\u09c1\u099e\u09cd\u099c"
+    ],
     "name:ceb_x_preferred":[
         "Haa Alifu Atholhu"
     ],
@@ -142,6 +145,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bb9\u0bbe \u0b85\u0bb3\u0bbf\u0baa\u0bcd \u0b85\u0b9f\u0bbe\u0bb2\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0bb9\u0bbe \u0b85\u0bb3\u0bbf\u0baa\u0bcd  \u0b85\u0b9f\u0bbe\u0bb2\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c39\u0c3e \u0c06\u0c32\u0c3f\u0c2b\u0c4d \u0c05\u0c1f\u0c4b\u0c32\u0c4d"
@@ -287,7 +293,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497505,
+    "wof:lastmodified":1690846526,
     "wof:name":"Haa Alifu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/53/85674053.geojson
+++ b/data/856/740/53/85674053.geojson
@@ -38,6 +38,9 @@
     "name:ben_x_preferred":[
         "\u09b9\u09be \u09a7\u09be\u09b2\u09c1 \u0986\u09a4\u09cb\u09b2"
     ],
+    "name:ben_x_variant":[
+        "\u09b9\u09be \u09a7\u09be\u09b2\u09c1 \u09aa\u09cd\u09b0\u09ac\u09be\u09b2 \u09a6\u09cd\u09ac\u09c0\u09aa\u09aa\u09c1\u099e\u09cd\u099c"
+    ],
     "name:ceb_x_preferred":[
         "Haa Dhaalu Atholhu"
     ],
@@ -67,6 +70,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0647\u0627\u0627 \u062f\u0647\u0627\u0644\u0648"
+    ],
+    "name:fas_x_variant":[
+        "\u0622\u0628\u200c\u0633\u0646\u06af \u062d\u0644\u0642\u0648\u06cc \u0647\u0627\u0626\u0648"
     ],
     "name:fin_x_preferred":[
         "Haa Dhaalu Atoll"
@@ -305,7 +311,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497504,
+    "wof:lastmodified":1690846525,
     "wof:name":"Haa Dhaalu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/77/85674077.geojson
+++ b/data/856/740/77/85674077.geojson
@@ -50,6 +50,9 @@
     "name:ces_x_preferred":[
         "K\u00e1fu"
     ],
+    "name:ces_x_variant":[
+        "Kaafu"
+    ],
     "name:dan_x_preferred":[
         "Kaafu Atoll"
     ],
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497505,
+    "wof:lastmodified":1690846526,
     "wof:name":"Kaafu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/89/85674089.geojson
+++ b/data/856/740/89/85674089.geojson
@@ -47,6 +47,9 @@
     "name:deu_x_preferred":[
         "Nord-Nilandhe-Atoll"
     ],
+    "name:deu_x_variant":[
+        "Faafu"
+    ],
     "name:div_x_preferred":[
         "\u0782\u07a8\u078d\u07a6\u0782\u07b0\u078b\u07ac\u0787\u07a6\u078c\u07ae\u0785\u07aa \u0787\u07aa\u078c\u07aa\u0783\u07aa\u0784\u07aa\u0783\u07a8"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:eng_x_variant":[
         "Faafu Atoll"
+    ],
+    "name:fas_x_preferred":[
+        "\u0641\u0627\u0641\u0648 \u0627\u062a\u0648\u0644"
     ],
     "name:fin_x_preferred":[
         "Faafu Atoll"
@@ -157,6 +163,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0641\u0627\u0641\u0648 \u0627\u062a\u0648\u0644"
+    ],
+    "name:uzb_x_preferred":[
+        "Faafu Atoll"
     ],
     "name:vie_x_preferred":[
         "Faafu Atoll"
@@ -284,7 +293,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497504,
+    "wof:lastmodified":1690846525,
     "wof:name":"Faafu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/93/85674093.geojson
+++ b/data/856/740/93/85674093.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.002845,
     "geom:area_square_m":35087547.342693,
-    "geom:bbox":"73.4312010656,4.16208746017,73.5528830121,4.24303891162",
+    "geom:bbox":"73.431201,4.162087,73.552883,4.243039",
     "geom:latitude":4.190794,
-    "geom:longitude":73.507554,
+    "geom:longitude":73.507553,
     "gn:population":105000,
     "iso:country":"MV",
     "label:eng_x_preferred_longname":[
@@ -41,6 +41,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0644\u064a\u0647"
     ],
+    "name:ary_x_preferred":[
+        "\u0645\u0627\u0644\u064a\u0647"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0644\u064a\u0647"
+    ],
     "name:ast_x_preferred":[
         "Mal\u00e9"
     ],
@@ -52,6 +58,9 @@
     ],
     "name:bak_x_preferred":[
         "\u041c\u0430\u043b\u0435"
+    ],
+    "name:ban_x_preferred":[
+        "Mal\u00e9"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u043b\u0435"
@@ -140,6 +149,9 @@
     "name:fra_x_preferred":[
         "Mal\u00e9"
     ],
+    "name:frr_x_preferred":[
+        "Mal\u00e9"
+    ],
     "name:fry_x_preferred":[
         "Malee"
     ],
@@ -163,6 +175,9 @@
     ],
     "name:hat_x_preferred":[
         "Male"
+    ],
+    "name:hau_x_preferred":[
+        "Mal\u00e9"
     ],
     "name:heb_x_preferred":[
         "\u05de\u05d0\u05dc\u05d4"
@@ -202,6 +217,9 @@
     ],
     "name:ita_x_preferred":[
         "Mal\u00e9"
+    ],
+    "name:ita_x_variant":[
+        "Male"
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30ec"
@@ -254,6 +272,9 @@
     "name:mar_x_preferred":[
         "\u092e\u093e\u0932\u0947"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u0430\u043b\u044d"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0430\u043b\u0435"
     ],
@@ -265,6 +286,12 @@
     ],
     "name:msa_x_preferred":[
         "Mal\u00e9"
+    ],
+    "name:mya_x_preferred":[
+        "\u1019\u102c\u101c\u1031\u1019\u103c\u102d\u102f\u1037"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0645\u0627\u0644\u0647"
     ],
     "name:nah_x_preferred":[
         "Male"
@@ -341,6 +368,9 @@
     "name:sme_x_preferred":[
         "Mal\u00e9"
     ],
+    "name:smn_x_preferred":[
+        "Mal\u00e9"
+    ],
     "name:sna_x_preferred":[
         "Mal\u00e9"
     ],
@@ -348,6 +378,9 @@
         "Mal\u00e9"
     ],
     "name:sqi_x_preferred":[
+        "Mal\u00e9"
+    ],
+    "name:srd_x_preferred":[
         "Mal\u00e9"
     ],
     "name:srp_x_preferred":[
@@ -383,6 +416,9 @@
     "name:tur_x_preferred":[
         "Mal\u00e9"
     ],
+    "name:udm_x_preferred":[
+        "\u041c\u0430\u043b\u0435"
+    ],
     "name:uig_x_preferred":[
         "\u0645\u0627\u0644\u06d0"
     ],
@@ -393,6 +429,9 @@
         "\u0645\u0627\u0644\u06d2"
     ],
     "name:uzb_x_preferred":[
+        "Male"
+    ],
+    "name:vec_x_preferred":[
         "Male"
     ],
     "name:vep_x_preferred":[
@@ -529,7 +568,7 @@
         890440959
     ],
     "wof:country":"MV",
-    "wof:geomhash":"d6f367ace374b8d48f776135ea2b5fe1",
+    "wof:geomhash":"b27b37a9ec4eeab349d3c71047a8fd8a",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -544,7 +583,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1566612145,
+    "wof:lastmodified":1690846525,
     "wof:name":"Mal\u00e9",
     "wof:parent_id":85632305,
     "wof:placetype":"region",
@@ -558,10 +597,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    73.43120106557677,
-    4.16208746016821,
-    73.55288301214136,
-    4.24303891161651
+    73.431201,
+    4.162087,
+    73.552883,
+    4.243039
 ],
-  "geometry": {"coordinates":[[[73.54619719124742,4.24303891161651],[73.55288301214136,4.23679881181579],[73.5519915690557,4.22833010564989],[73.54931724069814,4.21228413460517],[73.53817420527542,4.18331224196646],[73.52658544875953,4.1712777643574],[73.51089134286121,4.16208746016821],[73.48691624269048,4.16414622147102],[73.47666465035337,4.16860343510052],[73.43120106557677,4.18464940614524],[73.43209250866238,4.18999806375967],[73.51201489557104,4.18630088337909],[73.52053323801857,4.19112256885154],[73.52613972766636,4.20782692007634],[73.53327126965343,4.23100443400745],[73.54619719124742,4.24303891161651]]],"type":"Polygon"}
+  "geometry": {"coordinates":[[[73.54619700000001,4.243039],[73.55288299999999,4.236799],[73.551992,4.22833],[73.549317,4.212284],[73.538174,4.183312],[73.526585,4.171278],[73.510891,4.162087],[73.48691599999999,4.164146],[73.476665,4.168603],[73.431201,4.184649],[73.43209299999999,4.189998],[73.51201500000001,4.186301],[73.520533,4.191123],[73.52614,4.207827],[73.533271,4.231004],[73.54619700000001,4.243039]]],"type":"Polygon"}
 }

--- a/data/856/741/07/85674107.geojson
+++ b/data/856/741/07/85674107.geojson
@@ -44,6 +44,9 @@
     "name:deu_x_preferred":[
         "S\u00fcd-Nilandhe-Atoll"
     ],
+    "name:deu_x_variant":[
+        "Dhaalu"
+    ],
     "name:div_x_preferred":[
         "\u0782\u07a8\u078d\u07a6\u0782\u07b0\u078b\u07ac\u0787\u07a6\u078c\u07ae\u0785\u07aa \u078b\u07ac\u0786\u07aa\u0782\u07aa\u0784\u07aa\u0783\u07a8"
     ],
@@ -125,6 +128,9 @@
     "name:rus_x_preferred":[
         "\u0414\u0445\u0430\u0430\u043b\u0443"
     ],
+    "name:sat_x_preferred":[
+        "\u1c6b\u1c77\u1c5f\u1c5e\u1c69 \u1c6e\u1c74\u1c5a\u1c5e"
+    ],
     "name:sin_x_preferred":[
         "\u0da9\u0dcf\u0dbd\u0dd4 \u0daf\u0dd6\u0db4\u0dad\u0dca \u0dc3\u0db8\u0dd6\u0dc4\u0dba"
     ],
@@ -139,6 +145,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0ba4\u0bbe\u0bb3\u0bc1  \u0b85\u0b9f\u0bbe\u0bb2\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0ba4\u0bbe\u0bb3\u0bc1 \u0b85\u0b9f\u0bbe\u0bb2\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c22\u0c3e\u0c32\u0c41 \u0c05\u0c1f\u0c4b\u0c32\u0c4d"
@@ -285,7 +294,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497506,
+    "wof:lastmodified":1690846528,
     "wof:name":"Dhaalu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/11/85674111.geojson
+++ b/data/856/741/11/85674111.geojson
@@ -35,11 +35,17 @@
     "name:ben_x_preferred":[
         "\u09a5\u09be"
     ],
+    "name:ceb_x_preferred":[
+        "Thaa Atholhu"
+    ],
     "name:ces_x_preferred":[
         "T\u00e1"
     ],
     "name:deu_x_preferred":[
         "Kolhumadulu-Atoll"
+    ],
+    "name:deu_x_variant":[
+        "Kolhumadulu"
     ],
     "name:div_x_preferred":[
         "\u0786\u07ae\u0785\u07aa\u0789\u07a6\u0791\u07aa\u078d\u07aa"
@@ -106,6 +112,9 @@
     ],
     "name:swe_x_preferred":[
         "Thaa"
+    ],
+    "name:swe_x_variant":[
+        "Thaa Atholhu"
     ],
     "name:tha_x_preferred":[
         "\u0e01\u0e2d\u0e25\u0e39\u0e21\u0e32\u0e14\u0e39\u0e25\u0e39"
@@ -254,7 +263,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497506,
+    "wof:lastmodified":1690846528,
     "wof:name":"Thaa",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/15/85674115.geojson
+++ b/data/856/741/15/85674115.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u09b2\u09be\u09ae\u09c1 \u0986\u09a4\u09cb\u09b2"
     ],
+    "name:cat_x_preferred":[
+        "Atol Laamu"
+    ],
     "name:ceb_x_preferred":[
         "Laamu Atholhu"
     ],
@@ -290,7 +293,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497506,
+    "wof:lastmodified":1690846529,
     "wof:name":"Laamu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/21/85674121.geojson
+++ b/data/856/741/21/85674121.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u0997\u09cb\u09ab\u09c1 \u0986\u09b2\u09bf\u09ab \u0986\u09a4\u09cb\u09b2"
     ],
+    "name:ben_x_variant":[
+        "\u0997\u09be\u09ab\u09c1 \u0986\u09b2\u09bf\u09ab \u09aa\u09cd\u09b0\u09ac\u09be\u09b2 \u09a6\u09cd\u09ac\u09c0\u09aa\u09aa\u09c1\u099e\u09cd\u099c"
+    ],
     "name:ceb_x_preferred":[
         "Gaafu Alifu Atholhu"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:fas_x_preferred":[
         "\u06af\u0627\u0641\u0648 \u0627\u0644\u06cc\u0641\u0648"
+    ],
+    "name:fas_x_variant":[
+        "\u0622\u0628\u200c\u0633\u0646\u06af \u062d\u0644\u0642\u0648\u06cc \u06af\u0627\u0641\u0648 \u0627\u0644\u06cc\u0641"
     ],
     "name:fin_x_preferred":[
         "Gaafu Alif Atoll"
@@ -299,7 +305,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497506,
+    "wof:lastmodified":1690846528,
     "wof:name":"Gaafu Alifu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/25/85674125.geojson
+++ b/data/856/741/25/85674125.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u0997\u09be\u09ab\u09c1 \u09a7\u09be\u09b2\u09c1 \u0986\u09a4\u09cb\u09b2"
     ],
+    "name:ben_x_variant":[
+        "\u0997\u09be\u09ab\u09c1 \u09a7\u09be\u09b2\u09c1 \u09aa\u09cd\u09b0\u09ac\u09be\u09b2 \u09a6\u09cd\u09ac\u09c0\u09aa\u09aa\u09c1\u099e\u09cd\u099c"
+    ],
     "name:ceb_x_preferred":[
         "Gaafu Dhaalu Atholhu"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:fas_x_preferred":[
         "\u06af\u0627\u0641\u0648 \u062f\u0627\u0644\u0648"
+    ],
+    "name:fas_x_variant":[
+        "\u0622\u0628\u200c\u0633\u0646\u06af \u062d\u0644\u0642\u0648\u06cc \u063a\u0627\u0641\u0648"
     ],
     "name:fin_x_preferred":[
         "Gaafu Dhaalu Atoll"
@@ -148,6 +154,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbe\u0baa\u0bbf\u0baf\u0bc2  \u0ba4\u0baf\u0bbe\u0bb3\u0bc1 \u0b85\u0b9f\u0bcb\u0bb2\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0b95\u0bbe\u0baa\u0bbf\u0baf\u0bc2 \u0ba4\u0baf\u0bbe\u0bb3\u0bc1 \u0b85\u0b9f\u0bcb\u0bb2\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c17\u0c3e\u0c2b\u0c41 \u0c27\u0c3e\u0c32\u0c42 \u0c05\u0c1f\u0c4b\u0c32\u0c4d"
@@ -302,7 +311,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497506,
+    "wof:lastmodified":1690846529,
     "wof:name":"Gaafu Dhaalu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/33/85674133.geojson
+++ b/data/856/741/33/85674133.geojson
@@ -64,6 +64,9 @@
     "name:fas_x_preferred":[
         "\u062c\u06cc\u0646\u0627\u0648\u06cc\u0627\u0646\u06cc"
     ],
+    "name:fas_x_variant":[
+        "\u0622\u0628\u200c\u0633\u0646\u06af \u06af\u0646\u0627\u0648\u06cc\u0627\u0646\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Gnaviyani Atoll"
     ],
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497505,
+    "wof:lastmodified":1690846528,
     "wof:name":"Gnaviyani",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/890/430/437/890430437.geojson
+++ b/data/890/430/437/890430437.geojson
@@ -22,6 +22,9 @@
     "name:ceb_x_preferred":[
         "Mahibadhoo"
     ],
+    "name:deu_x_preferred":[
+        "Mahibadhoo"
+    ],
     "name:div_x_preferred":[
         "\u0789\u07a6\u0780\u07a8\u0784\u07a6\u078b\u07ab"
     ],
@@ -30,6 +33,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u0647\u06cc\u0628\u0627\u062f\u0647\u0648"
+    ],
+    "name:ita_x_preferred":[
+        "Mahibadhoo"
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30d2\u30d0\u30c9\u30db\u30fc"
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":890430437,
-    "wof:lastmodified":1566612152,
+    "wof:lastmodified":1690846531,
     "wof:name":"Mahibadhoo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/431/475/890431475.geojson
+++ b/data/890/431/475/890431475.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Eydhafushi"
     ],
+    "name:deu_x_preferred":[
+        "Eydhafushi"
+    ],
     "name:div_x_preferred":[
         "\u0787\u07ad\u078b\u07a6\u078a\u07aa\u0781\u07a8"
     ],
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":890431475,
-    "wof:lastmodified":1566612152,
+    "wof:lastmodified":1690846532,
     "wof:name":"Eydhafushi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/431/481/890431481.geojson
+++ b/data/890/431/481/890431481.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u062f\u0627\u0647\u0648\u06a4\u0627\u062f\u0647\u0648"
+    ],
     "name:bul_x_preferred":[
         "\u041a\u0443\u0434\u0430\u0445\u0443\u0432\u0430\u0434\u0445\u043e"
     ],
@@ -44,6 +47,9 @@
         "Kudahuvadhoo"
     ],
     "name:nld_x_preferred":[
+        "Kudahuvadhoo"
+    ],
+    "name:pol_x_preferred":[
         "Kudahuvadhoo"
     ],
     "name:slk_x_preferred":[
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890431481,
-    "wof:lastmodified":1566612152,
+    "wof:lastmodified":1690846531,
     "wof:name":"Kudahuvadhoo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/431/485/890431485.geojson
+++ b/data/890/431/485/890431485.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Kulhudhuffushi"
     ],
+    "name:deu_x_preferred":[
+        "Kulhudhuffushi"
+    ],
     "name:div_x_preferred":[
         "\u0786\u07aa\u0785\u07aa\u078b\u07aa\u0787\u07b0\u078a\u07aa\u0781\u07a8"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:fra_x_preferred":[
         "Kulhudhuffushi"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d5\u05dc\u05d7\u05d5\u05d3\u05d5\u05e4\u05d5\u05e9\u05d9"
     ],
     "name:nld_x_preferred":[
         "Kulhudhuffushi"
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890431485,
-    "wof:lastmodified":1566612152,
+    "wof:lastmodified":1690846531,
     "wof:name":"Kulhudhuffushi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/431/489/890431489.geojson
+++ b/data/890/431/489/890431489.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Manadhoo"
     ],
+    "name:deu_x_preferred":[
+        "Manadhoo"
+    ],
     "name:div_x_preferred":[
         "\u0789\u07a6\u0782\u07a6\u078b\u07ab"
     ],
@@ -37,7 +40,13 @@
     "name:fra_x_preferred":[
         "Manadhoo"
     ],
+    "name:jpn_x_preferred":[
+        "\u30de\u30ca\u30c9\u30a5\u30fc"
+    ],
     "name:nld_x_preferred":[
+        "Manadhoo"
+    ],
+    "name:pol_x_preferred":[
         "Manadhoo"
     ],
     "name:rus_x_preferred":[
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":890431489,
-    "wof:lastmodified":1566612152,
+    "wof:lastmodified":1690846532,
     "wof:name":"Manadhoo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/433/705/890433705.geojson
+++ b/data/890/433/705/890433705.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Hithadhoo"
     ],
+    "name:deu_x_preferred":[
+        "Hithadhoo"
+    ],
     "name:div_x_preferred":[
         "\u0780\u07a8\u078c\u07a6\u078b\u07ab"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890433705,
-    "wof:lastmodified":1566612153,
+    "wof:lastmodified":1690846532,
     "wof:name":"Hithadhoo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/440/959/890440959.geojson
+++ b/data/890/440/959/890440959.geojson
@@ -33,6 +33,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0644\u064a\u0647"
     ],
+    "name:ary_x_preferred":[
+        "\u0645\u0627\u0644\u064a\u0647"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0644\u064a\u0647"
+    ],
     "name:ast_x_preferred":[
         "Mal\u00e9"
     ],
@@ -45,8 +51,14 @@
     "name:bak_x_preferred":[
         "\u041c\u0430\u043b\u0435"
     ],
+    "name:ban_x_preferred":[
+        "Mal\u00e9"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u043b\u0435"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0430\u043b\u0435"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09b2\u09c7"
@@ -126,6 +138,9 @@
     "name:fra_x_preferred":[
         "Mal\u00e9"
     ],
+    "name:frr_x_preferred":[
+        "Mal\u00e9"
+    ],
     "name:fry_x_preferred":[
         "Malee"
     ],
@@ -149,6 +164,9 @@
     ],
     "name:hat_x_preferred":[
         "Male"
+    ],
+    "name:hau_x_preferred":[
+        "Mal\u00e9"
     ],
     "name:heb_x_preferred":[
         "\u05de\u05d0\u05dc\u05d4"
@@ -191,6 +209,9 @@
     ],
     "name:ita_x_preferred":[
         "Mal\u00e9"
+    ],
+    "name:ita_x_variant":[
+        "Male"
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30ec"
@@ -243,6 +264,9 @@
     "name:mar_x_preferred":[
         "\u092e\u093e\u0932\u0947"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u0430\u043b\u044d"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0430\u043b\u0435"
     ],
@@ -254,6 +278,12 @@
     ],
     "name:msa_x_preferred":[
         "Mal\u00e9"
+    ],
+    "name:mya_x_preferred":[
+        "\u1019\u102c\u101c\u1031\u1019\u103c\u102d\u102f\u1037"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0645\u0627\u0644\u0647"
     ],
     "name:nah_x_preferred":[
         "Male"
@@ -336,6 +366,9 @@
     "name:sme_x_preferred":[
         "Mal\u00e9"
     ],
+    "name:smn_x_preferred":[
+        "Mal\u00e9"
+    ],
     "name:sna_x_preferred":[
         "Mal\u00e9"
     ],
@@ -343,6 +376,9 @@
         "Mal\u00e9"
     ],
     "name:sqi_x_preferred":[
+        "Mal\u00e9"
+    ],
+    "name:srd_x_preferred":[
         "Mal\u00e9"
     ],
     "name:srp_x_preferred":[
@@ -384,6 +420,9 @@
     "name:tur_x_variant":[
         "Mal\u00e9"
     ],
+    "name:udm_x_preferred":[
+        "\u041c\u0430\u043b\u0435"
+    ],
     "name:uig_x_preferred":[
         "\u0645\u0627\u0644\u06d0"
     ],
@@ -397,6 +436,9 @@
         "\u0645\u0627\u0644\u06d2"
     ],
     "name:uzb_x_preferred":[
+        "Male"
+    ],
+    "name:vec_x_preferred":[
         "Male"
     ],
     "name:vep_x_preferred":[
@@ -470,7 +512,7 @@
         }
     ],
     "wof:id":890440959,
-    "wof:lastmodified":1607390888,
+    "wof:lastmodified":1690846531,
     "wof:name":"Male",
     "wof:parent_id":85674093,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.