### PR TITLE
mv concordances, placetype local, and more

### DIFF
--- a/data/856/323/05/85632305.geojson
+++ b/data/856/323/05/85632305.geojson
@@ -1173,6 +1173,7 @@
         "hasc:id":"MV",
         "icao:code":"8Q",
         "ioc:id":"MDV",
+        "iso:code":"MV",
         "itu:id":"MLD",
         "loc:id":"n81139903",
         "m49:code":"462",
@@ -1187,6 +1188,7 @@
         "wk:page":"Maldives",
         "wmo:id":"MV"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
     "wof:country_alpha3":"MDV",
     "wof:geom_alt":[
@@ -1207,7 +1209,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1694639522,
+    "wof:lastmodified":1695881177,
     "wof:name":"Maldives",
     "wof:parent_id":102193527,
     "wof:placetype":"country",

--- a/data/856/740/49/85674049.geojson
+++ b/data/856/740/49/85674049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000649,
-    "geom:area_square_m":7965265.353679,
+    "geom:area_square_m":7965454.592815,
     "geom:bbox":"72.882498,6.821112,73.214041,7.107245",
     "geom:latitude":6.909947,
     "geom:longitude":73.138396,
@@ -273,12 +273,14 @@
         "gn:id":1282294,
         "gp:id":20070312,
         "hasc:id":"MV.HA",
+        "iso:code":"MV-07",
         "iso:id":"MV-07",
         "qs_pg:id":890124,
         "wd:id":"Q2360912"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"8e723d138334ed84929cfe4cb89b06be",
+    "wof:geomhash":"37e248f54c5a5104b6514db14ac9740d",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -293,7 +295,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846526,
+    "wof:lastmodified":1695884853,
     "wof:name":"Haa Alifu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/53/85674053.geojson
+++ b/data/856/740/53/85674053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000794,
-    "geom:area_square_m":9750305.839481,
+    "geom:area_square_m":9750698.937683,
     "geom:bbox":"72.684825,6.40648,73.166515,6.787055",
     "geom:latitude":6.724121,
     "geom:longitude":73.107933,
@@ -290,13 +290,15 @@
         "gn:id":1282293,
         "gp:id":20070318,
         "hasc:id":"MV.HD",
+        "iso:code":"MV-23",
         "iso:id":"MV-23",
         "qs_pg:id":1172852,
         "unlc:id":"MV-23",
         "wd:id":"Q2360368"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"fcb5143243fcd646581ba7dd4c8760b5",
+    "wof:geomhash":"75b75cfaabba2174c74637bb9fe27de1",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846525,
+    "wof:lastmodified":1695884853,
     "wof:name":"Haa Dhaalu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/57/85674057.geojson
+++ b/data/856/740/57/85674057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000257,
-    "geom:area_square_m":3164555.647482,
+    "geom:area_square_m":3164607.262937,
     "geom:bbox":"72.89088,6.079535,73.270844,6.452094",
     "geom:latitude":6.297736,
     "geom:longitude":73.126485,
@@ -271,14 +271,16 @@
         "gn:id":1281892,
         "gp:id":20070314,
         "hasc:id":"MV.SH",
+        "iso:code":"MV-24",
         "iso:id":"MV-24",
         "qs_pg:id":212340,
         "unlc:id":"MV-24",
         "wd:id":"Q2190334",
         "wk:page":"Shaviyani Atoll"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"19ae1ea913ef04bea06ee917b0fc09b1",
+    "wof:geomhash":"e3d50a528fe2d458921c50ce4e04f7e0",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -293,7 +295,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497503,
+    "wof:lastmodified":1695884852,
     "wof:name":"Shaviyani",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/61/85674061.geojson
+++ b/data/856/740/61/85674061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000265,
-    "geom:area_square_m":3259963.421392,
+    "geom:area_square_m":3259948.76669,
     "geom:bbox":"72.877696,5.456244,73.019054,5.982733",
     "geom:latitude":5.716178,
     "geom:longitude":72.965537,
@@ -274,14 +274,16 @@
         "gn:id":1281918,
         "gp:id":20070317,
         "hasc:id":"MV.RA",
+        "iso:code":"MV-13",
         "iso:id":"MV-13",
         "qs_pg:id":424312,
         "unlc:id":"MV-13",
         "wd:id":"Q1457965",
         "wk:page":"Raa Atoll"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"fd26870c7961abf8ad5b86c7b3811a24",
+    "wof:geomhash":"d6db93ec82f84920b08a7a308307651d",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -296,7 +298,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497503,
+    "wof:lastmodified":1695884852,
     "wof:name":"Raa",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/63/85674063.geojson
+++ b/data/856/740/63/85674063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0002,
-    "geom:area_square_m":2458298.459652,
+    "geom:area_square_m":2458126.080834,
     "geom:bbox":"73.376801,5.714586,73.44988,5.970282",
     "geom:latitude":5.854243,
     "geom:longitude":73.404073,
@@ -276,14 +276,16 @@
         "gn:id":1281937,
         "gp:id":20070315,
         "hasc:id":"MV.NO",
+        "iso:code":"MV-25",
         "iso:id":"MV-25",
         "qs_pg:id":424311,
         "unlc:id":"MV-25",
         "wd:id":"Q2406322",
         "wk:page":"Noonu Atoll"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"dd9a79d5ef4c7cbb9bf44d29c6a7140a",
+    "wof:geomhash":"c12df8c06d4c720a9e9a7df00a05ba80",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -298,7 +300,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497505,
+    "wof:lastmodified":1695884853,
     "wof:name":"Noonu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/67/85674067.geojson
+++ b/data/856/740/67/85674067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000112,
-    "geom:area_square_m":1377463.890539,
+    "geom:area_square_m":1377420.679498,
     "geom:bbox":"72.856619,4.88052,73.131847,5.352769",
     "geom:latitude":5.014465,
     "geom:longitude":72.999634,
@@ -148,12 +148,14 @@
         "gn:id":1282478,
         "gp:id":20070316,
         "hasc:id":"MV.BA",
+        "iso:code":"MV-20",
         "iso:id":"MV-20",
         "qs_pg:id":890126,
         "unlc:id":"MV-20"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"06570d23f64430872c0269c7f2de8304",
+    "wof:geomhash":"2b0688436e3ed459dcce5cafb843bab0",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -168,7 +170,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497504,
+    "wof:lastmodified":1695884853,
     "wof:name":"Baa",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/73/85674073.geojson
+++ b/data/856/740/73/85674073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000332,
-    "geom:area_square_m":4083861.574778,
+    "geom:area_square_m":4083789.510206,
     "geom:bbox":"73.317719,5.245022,73.646658,5.543606",
     "geom:latitude":5.361057,
     "geom:longitude":73.55689,
@@ -269,13 +269,15 @@
         "gn:id":1282096,
         "gp:id":20070313,
         "hasc:id":"MV.LV",
+        "iso:code":"MV-03",
         "iso:id":"MV-03",
         "qs_pg:id":890125,
         "unlc:id":"MV-03",
         "wd:id":"Q1390048"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"422ab2d37444d1614ec5b8f342e26294",
+    "wof:geomhash":"e063ec033dafebdcd66c824b217711a0",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -290,7 +292,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497504,
+    "wof:lastmodified":1695884853,
     "wof:name":"Lhaviyani",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/77/85674077.geojson
+++ b/data/856/740/77/85674077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000238,
-    "geom:area_square_m":2940200.032476,
+    "geom:area_square_m":2940279.856579,
     "geom:bbox":"73.341482,3.841702,73.70281,4.974921",
     "geom:latitude":4.398538,
     "geom:longitude":73.513382,
@@ -284,13 +284,15 @@
         "gn:id":1282208,
         "gp:id":20070330,
         "hasc:id":"MV.KA",
+        "iso:code":"MV-26",
         "iso:id":"MV-26",
         "qs_pg:id":1172855,
         "unlc:id":"MV-26",
         "wd:id":"Q1468407"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"1b21b4bbabe685e4a5776dae228dcc1a",
+    "wof:geomhash":"8cf9e23a0bbb7c32c373ad7a4a89bb22",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846526,
+    "wof:lastmodified":1695884853,
     "wof:name":"Kaafu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/81/85674081.geojson
+++ b/data/856/740/81/85674081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000201,
-    "geom:area_square_m":2473176.562514,
+    "geom:area_square_m":2473245.220581,
     "geom:bbox":"72.699067,3.996405,72.975759,4.4383",
     "geom:latitude":4.349689,
     "geom:longitude":72.922433,
@@ -76,10 +76,12 @@
         "fips:code":"MV30",
         "gp:id":20070319,
         "hasc:id":"MV.AA",
+        "iso:code":"MV-02",
         "iso:id":"MV-02"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"0ff50db6c4570c92ab74652ee89a2e51",
+    "wof:geomhash":"8b95eb21140f9218320df1f82c8d33d4",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -94,7 +96,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497504,
+    "wof:lastmodified":1695884853,
     "wof:name":"Alifu Alifu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/85/85674085.geojson
+++ b/data/856/740/85/85674085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000252,
-    "geom:area_square_m":3112310.056015,
+    "geom:area_square_m":3112222.227521,
     "geom:bbox":"72.689708,3.503567,72.955821,3.836859",
     "geom:latitude":3.647452,
     "geom:longitude":72.866874,
@@ -86,11 +86,13 @@
         "fips:code":"MV30",
         "gp:id":20070319,
         "hasc:id":"MV.AD",
+        "iso:code":"MV-00",
         "iso:id":"MV-00",
         "unlc:id":"MV-00"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"f38ba0371d1dd978f86878cf34c821aa",
+    "wof:geomhash":"7b4079a120ebdc20016673505c35f656",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -105,7 +107,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497505,
+    "wof:lastmodified":1695884853,
     "wof:name":"Alifu Dhaalu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/89/85674089.geojson
+++ b/data/856/740/89/85674089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000127,
-    "geom:area_square_m":1571024.698967,
+    "geom:area_square_m":1570974.878534,
     "geom:bbox":"72.831228,3.07685,73.046886,3.312486",
     "geom:latitude":3.188647,
     "geom:longitude":72.959293,
@@ -271,14 +271,16 @@
         "gn:id":1282393,
         "gp:id":20070321,
         "hasc:id":"MV.FA",
+        "iso:code":"MV-14",
         "iso:id":"MV-14",
         "qs_pg:id":219917,
         "unlc:id":"MV-14",
         "wd:id":"Q2469227",
         "wk:page":"Faafu Atoll"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"32a1c024aaab6c43af39052a0415cb43",
+    "wof:geomhash":"1a346f4449631b019dd38b85f20f94f0",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -293,7 +295,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846525,
+    "wof:lastmodified":1695884853,
     "wof:name":"Faafu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/93/85674093.geojson
+++ b/data/856/740/93/85674093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002845,
-    "geom:area_square_m":35087547.342693,
+    "geom:area_square_m":35087885.188236,
     "geom:bbox":"73.431201,4.162087,73.552883,4.243039",
     "geom:latitude":4.190794,
     "geom:longitude":73.507553,
@@ -558,17 +558,19 @@
         "gn:id":1337624,
         "gp:id":20070331,
         "hasc:id":"MV.MA",
+        "iso:code":"MV-MLE",
         "iso:id":"MV-MLE",
         "loc:id":"n82095066",
         "qs_pg:id":1287668,
         "wd:id":"Q9347",
         "wk:page":"Mal\u00e9"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890440959
     ],
     "wof:country":"MV",
-    "wof:geomhash":"b27b37a9ec4eeab349d3c71047a8fd8a",
+    "wof:geomhash":"6245c65f8c58cb68fa3c98d2de3f9f62",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -583,7 +585,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846525,
+    "wof:lastmodified":1695884325,
     "wof:name":"Mal\u00e9",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/740/97/85674097.geojson
+++ b/data/856/740/97/85674097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000013,
-    "geom:area_square_m":159726.657894,
+    "geom:area_square_m":159703.222924,
     "geom:bbox":"73.50587,3.356391,73.753184,3.501207",
     "geom:latitude":3.444528,
     "geom:longitude":73.621832,
@@ -269,13 +269,15 @@
         "gn:id":1281843,
         "gp:id":20070320,
         "hasc:id":"MV.WA",
+        "iso:code":"MV-04",
         "iso:id":"MV-04",
         "qs_pg:id":332309,
         "unlc:id":"MV-04",
         "wd:id":"Q2709111"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"d36227f76a4a9f0e653bb0d769ffaf36",
+    "wof:geomhash":"40a90d588e75ef2878c2eabf6eeb6493",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -290,7 +292,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497504,
+    "wof:lastmodified":1695884853,
     "wof:name":"Vaavu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/01/85674101.geojson
+++ b/data/856/741/01/85674101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000112,
-    "geom:area_square_m":1388152.267881,
+    "geom:area_square_m":1388132.796526,
     "geom:bbox":"73.348481,2.770697,73.613048,3.106757",
     "geom:latitude":2.875738,
     "geom:longitude":73.454106,
@@ -265,14 +265,16 @@
         "gn:id":1281985,
         "gp:id":20070323,
         "hasc:id":"MV.ME",
+        "iso:code":"MV-12",
         "iso:id":"MV-12",
         "qs_pg:id":219918,
         "unlc:id":"MV-12",
         "wd:id":"Q2210716",
         "wk:page":"Meemu Atoll"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"4bdfee507a2370defe307039626cf137",
+    "wof:geomhash":"efeb5c697a6adaea1347d3351ea5ea51",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -287,7 +289,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497506,
+    "wof:lastmodified":1695884853,
     "wof:name":"Meemu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/07/85674107.geojson
+++ b/data/856/741/07/85674107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000136,
-    "geom:area_square_m":1682036.577957,
+    "geom:area_square_m":1681962.244683,
     "geom:bbox":"72.864919,2.675727,73.032237,2.969184",
     "geom:latitude":2.775684,
     "geom:longitude":72.938933,
@@ -274,12 +274,14 @@
         "gn:id":1282447,
         "gp:id":20070322,
         "hasc:id":"MV.DA",
+        "iso:code":"MV-17",
         "iso:id":"MV-17",
         "qs_pg:id":890127,
         "wd:id":"Q2290784"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"36c44d85d1c6571fe05f23028d5e124b",
+    "wof:geomhash":"094ceafb9eaabbefa4eac8915fbd7c13",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846528,
+    "wof:lastmodified":1695884853,
     "wof:name":"Dhaalu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/11/85674111.geojson
+++ b/data/856/741/11/85674111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000412,
-    "geom:area_square_m":5083987.487606,
+    "geom:area_square_m":5083962.729655,
     "geom:bbox":"72.922374,2.164537,73.367035,2.55329",
     "geom:latitude":2.38473,
     "geom:longitude":73.292869,
@@ -241,14 +241,16 @@
         "gn:id":1281881,
         "gp:id":20070324,
         "hasc:id":"MV.TH",
+        "iso:code":"MV-08",
         "iso:id":"MV-08",
         "qs_pg:id":1287670,
         "unlc:id":"MV-08",
         "wd:id":"Q2709118",
         "wk:page":"Kolhumadulu Atoll"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"b13fd301fc12101374a584c5951068fe",
+    "wof:geomhash":"2bf2de26f18c3c87a62bbff300d62cfa",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -263,7 +265,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846528,
+    "wof:lastmodified":1695884853,
     "wof:name":"Thaa",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/15/85674115.geojson
+++ b/data/856/741/15/85674115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000548,
-    "geom:area_square_m":6775328.085654,
+    "geom:area_square_m":6775452.218148,
     "geom:bbox":"73.243663,1.782538,73.58546,2.109931",
     "geom:latitude":1.942316,
     "geom:longitude":73.484719,
@@ -271,14 +271,16 @@
         "gn:id":1282101,
         "gp:id":20070325,
         "hasc:id":"MV.LM",
+        "iso:code":"MV-05",
         "iso:id":"MV-05",
         "qs_pg:id":1287671,
         "unlc:id":"MV-05",
         "wd:id":"Q1996432",
         "wk:page":"Laamu Atoll"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"cf6eb7175cbbb6536ba3a729f473d150",
+    "wof:geomhash":"4de2d0eeab56dad73c38fa285c5c0535",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -293,7 +295,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846529,
+    "wof:lastmodified":1695884853,
     "wof:name":"Laamu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/21/85674121.geojson
+++ b/data/856/741/21/85674121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000096,
-    "geom:area_square_m":1188421.95902,
+    "geom:area_square_m":1188351.759942,
     "geom:bbox":"73.349783,0.380561,73.513438,0.847724",
     "geom:latitude":0.591601,
     "geom:longitude":73.435245,
@@ -284,13 +284,15 @@
         "gn:id":1282329,
         "gp:id":20070328,
         "hasc:id":"MV.GA",
+        "iso:code":"MV-27",
         "iso:id":"MV-27",
         "qs_pg:id":890129,
         "unlc:id":"MV-27",
         "wd:id":"Q1116203"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"275f8a5cb9056ce4586a539c38357573",
+    "wof:geomhash":"5b2423d0e56c095d009817a597127119",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846528,
+    "wof:lastmodified":1695884853,
     "wof:name":"Gaafu Alifu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/25/85674125.geojson
+++ b/data/856/741/25/85674125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000201,
-    "geom:area_square_m":2481768.676913,
+    "geom:area_square_m":2481808.927195,
     "geom:bbox":"72.937022,0.213446,73.379161,0.496324",
     "geom:latitude":0.286644,
     "geom:longitude":73.114063,
@@ -290,13 +290,15 @@
         "gn:id":1282328,
         "gp:id":20070327,
         "hasc:id":"MV.GD",
+        "iso:code":"MV-28",
         "iso:id":"MV-28",
         "qs_pg:id":890128,
         "unlc:id":"MV-28",
         "wd:id":"Q2640183"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"7fce90df5a46ff85d0a417fc82b2c944",
+    "wof:geomhash":"b230af5a575f97d0171670441f66bc4f",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846529,
+    "wof:lastmodified":1695884853,
     "wof:name":"Gaafu Dhaalu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/33/85674133.geojson
+++ b/data/856/741/33/85674133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000104,
-    "geom:area_square_m":1290264.931888,
+    "geom:area_square_m":1290206.38879,
     "geom:bbox":"73.434581,-0.304295,73.445079,-0.283624",
     "geom:latitude":-0.294335,
     "geom:longitude":73.439709,
@@ -283,13 +283,15 @@
         "gn:id":1281945,
         "gp:id":20070326,
         "hasc:id":"MV.NA",
+        "iso:code":"MV-29",
         "iso:id":"MV-29",
         "qs_pg:id":1172854,
         "unlc:id":"MV-29",
         "wd:id":"Q1811116"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"92acdbc64d64a6473701f812f5a39c08",
+    "wof:geomhash":"20020fe3f59ad01e75cfa4875ef02855",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -304,7 +306,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1690846528,
+    "wof:lastmodified":1695884853,
     "wof:name":"Gnaviyani",
     "wof:parent_id":85632305,
     "wof:placetype":"region",

--- a/data/856/741/35/85674135.geojson
+++ b/data/856/741/35/85674135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000966,
-    "geom:area_square_m":11942800.412894,
+    "geom:area_square_m":11942748.637001,
     "geom:bbox":"73.091156,-0.688572,73.248383,-0.577895",
     "geom:latitude":-0.618095,
     "geom:longitude":73.159446,
@@ -254,14 +254,16 @@
         "gn:id":1281893,
         "gp:id":20070329,
         "hasc:id":"MV.SE",
+        "iso:code":"MV-01",
         "iso:id":"MV-01",
         "qs_pg:id":1287672,
         "unlc:id":"MV-01",
         "wd:id":"Q353375",
         "wk:page":"Addu Atoll"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MV",
-    "wof:geomhash":"e109d9fc05e0fb5f9ccf53b1bfd78598",
+    "wof:geomhash":"cbd471f491f2433cfb0ea78271080eaf",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -276,7 +278,7 @@
     "wof:lang_x_spoken":[
         "div"
     ],
-    "wof:lastmodified":1636497505,
+    "wof:lastmodified":1695884853,
     "wof:name":"Addu",
     "wof:parent_id":85632305,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.